### PR TITLE
Improve deprecations on "create customer card" and "delete customer card" request/response classes

### DIFF
--- a/src/Apis/CustomersApi.php
+++ b/src/Apis/CustomersApi.php
@@ -524,7 +524,7 @@ class CustomersApi extends BaseApi
      * calls with the same card nonce return the same card record that was created
      * with the provided nonce during the _first_ call.
      *
-     * @deprecated
+     * @deprecated Use createCard() through the Cards API and specify a customer ID instead
      *
      * @param string $customerId The Square ID of the customer profile the card is linked to.
      * @param \Square\Models\CreateCustomerCardRequest $body An object containing the fields to POST
@@ -604,7 +604,7 @@ class CustomersApi extends BaseApi
     /**
      * Removes a card on file from a customer.
      *
-     * @deprecated
+     * @deprecated Use disableCard() through the Cards API instead
      *
      * @param string $customerId The ID of the customer that the card on file belongs to.
      * @param string $cardId The ID of the card on file to delete.

--- a/src/Models/CreateCustomerCardRequest.php
+++ b/src/Models/CreateCustomerCardRequest.php
@@ -7,6 +7,8 @@ namespace Square\Models;
 /**
  * Defines the fields that are included in the request body of a request
  * to the `CreateCustomerCard` endpoint.
+ *
+ * @deprecated
  */
 class CreateCustomerCardRequest implements \JsonSerializable
 {

--- a/src/Models/CreateCustomerCardResponse.php
+++ b/src/Models/CreateCustomerCardResponse.php
@@ -9,6 +9,8 @@ namespace Square\Models;
  * a request to the `CreateCustomerCard` endpoint.
  *
  * Either `errors` or `card` is present in a given response (never both).
+ *
+ * @deprecated
  */
 class CreateCustomerCardResponse implements \JsonSerializable
 {

--- a/src/Models/DeleteCustomerCardResponse.php
+++ b/src/Models/DeleteCustomerCardResponse.php
@@ -7,6 +7,8 @@ namespace Square\Models;
 /**
  * Defines the fields that are included in the response body of
  * a request to the `DeleteCustomerCard` endpoint.
+ *
+ * @deprecated
  */
 class DeleteCustomerCardResponse implements \JsonSerializable
 {


### PR DESCRIPTION
The request and responses for these two methods should be deprecated also.

This PR also improves the deprecation message by providing the suggested replacement, which I found through [the changelog](https://github.com/square/square-php-sdk/blob/master/CHANGELOG.md#api-updates-1) after some digging.