### PR TITLE
updated example-autoload.php to use core-lib and core-interfaces

### DIFF
--- a/example-autoload.php
+++ b/example-autoload.php
@@ -24,8 +24,9 @@ spl_autoload_register(function ($class) {
     $prefixToLocation = [
         "Square\\" => "/square-php-sdk/src/",
         "apimatic\\jsonmapper\\" => "/jsonmapper/src/",
-        // This is the Namespace and location from Apimatic/Unirest's composer.json
         "Unirest\\" => "/unirest-php/src/",
+        "Core\\" => "/core-lib-php/src/",
+        "CoreInterfaces\\" => "/core-interfaces-php/src/",
     ];
 
     $matchingPrefix;


### PR DESCRIPTION
Square PHP SDK requires core-lib-php and core-interfaces-php.  If you use Composer, this is handled automatically; otherwise, you can use this (updated) example-autoload.php as a starting point for manual config.