### PR TITLE
Boolean as a parameter in the request object will result to '1' or '0  in the http request, which is not supported by the API

### DIFF
--- a/src/Core/Client/RawClient.php
+++ b/src/Core/Client/RawClient.php
@@ -250,6 +250,9 @@ class RawClient
         if (is_string($value)) {
             return urlencode($value);
         }
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
         if (is_scalar($value)) {
             return urlencode((string)$value);
         }


### PR DESCRIPTION
Boolean as a parameter in the request object will result to '1' or '0  in the http request, which is not supported by the API

e.g. setting "withDefinitions" to true in  ListOrderCustomAttributesRequest will be translated to /custom-attributes?with_definitions=1 in the http request